### PR TITLE
New Albums use track image + new album id returned and used when crea…

### DIFF
--- a/client/apps/web/src/main.tsx
+++ b/client/apps/web/src/main.tsx
@@ -40,9 +40,7 @@ Object.entries(routerMap).forEach(([path, component]) => {
 });
 
 const apiUrl =
-  import.meta.env.MODE === 'development'
-    ? 'https://127.0.0.1:5129/api'
-    : '/api';
+  import.meta.env.MODE === 'development' ? 'http://localhost:5129/api' : '/api';
 initialiseAxios(apiUrl);
 
 createRoot(document.getElementById('root')!).render(

--- a/client/apps/web/src/routes/artist/index.tsx
+++ b/client/apps/web/src/routes/artist/index.tsx
@@ -1,14 +1,13 @@
+import { Await, useLoaderData, useNavigate } from '@melodiy/router';
 import { TopTracksTable } from '@melodiy/ui/collections';
 import {
   CollectionCard,
   CollectionCardSize,
 } from '@melodiy/ui/components/Cards';
 import * as Tabs from '@radix-ui/react-tabs';
-import { Await } from '@melodiy/router';
 import { Suspense } from 'react';
 import { FaSpinner } from 'react-icons/fa';
 import { ArtistHeader } from './ArtistHeader';
-import { useLoaderData, useNavigate } from '@melodiy/router';
 
 export default function Artist() {
   const navigate = useNavigate();
@@ -81,10 +80,6 @@ export default function Artist() {
 
                     <Tabs.Content className="w-full" value="home">
                       <div className="flex flex-col px-5 gap-y-4">
-                        <TopTracksTable tracks={artist.topTracks} />
-                        <TopTracksTable tracks={artist.topTracks} />
-                        <TopTracksTable tracks={artist.topTracks} />
-                        <TopTracksTable tracks={artist.topTracks} />
                         <TopTracksTable tracks={artist.topTracks} />
                       </div>
                     </Tabs.Content>

--- a/client/packages/api/src/lib/track.ts
+++ b/client/packages/api/src/lib/track.ts
@@ -25,10 +25,15 @@ export async function fetchUserTracks(): Promise<Track[]> {
 export async function UpoloadTrack(
   formData: FormData,
   isPublic: boolean
-): Promise<boolean> {
+): Promise<Track> {
   try {
-    await AXIOS.post(`track?public=${isPublic}`, formData);
-    return true;
+    const response = await AXIOS.post<Track>(
+      `track?public=${isPublic}`,
+      formData
+    );
+    if (response.data == null) throw new Error('Unable to create track');
+
+    return response.data;
   } catch (err) {
     throw getApiError(err).message;
   }

--- a/client/packages/ui/src/components/Modals/MultiUpload/UploadTrackMenu.tsx
+++ b/client/packages/ui/src/components/Modals/MultiUpload/UploadTrackMenu.tsx
@@ -49,7 +49,7 @@ const schema = z.object({
               data.item(0) !== null &&
               (data.item(0)?.type === 'audio/mpeg' ||
                 data.item(0)?.type === 'audio/wav'),
-            'Only MP3 and Wav files are supported',
+            'Only MP3 and Wav files are supported'
           ),
   // .refine((data) => data.),
 });
@@ -98,7 +98,7 @@ function UploadTrackMenu() {
 
   const { query: albumQuery, loading: loadingAlbum } = useAlbumSearch(
     album?.name,
-    artist.id,
+    artist.id
   );
 
   const setTags = useCallback(() => {
@@ -152,7 +152,17 @@ function UploadTrackMenu() {
     }
 
     try {
-      await UpoloadTrack(formData, data.public);
+      const createdTrack = await UpoloadTrack(formData, data.public);
+      if (createdTrack.album != null) {
+        const updatedComboItem: ComboBoxItem = {
+          id: createdTrack.album.id,
+          name: createdTrack.album.title,
+          verified: false,
+        };
+
+        setValue('album', updatedComboItem);
+      }
+
       toast.success('Successfully Created Track');
     } catch (err) {
       toast.error(getApiError(err).message);

--- a/server/Melodiy.Features/Track/TrackController.cs
+++ b/server/Melodiy.Features/Track/TrackController.cs
@@ -65,7 +65,7 @@ public class TrackController(IUserService userService, IMediator mediator) : Con
                 Title = request.AlbumTitle,
                 ArtistSlug = request.ArtistId!,
                 Timestamp = 0,
-                Image = null,
+                Image = request.Image,
                 UserId = user.Id
             });
 


### PR DESCRIPTION
Some minor fixes to make the user experience better when creating and uploading new albums and tracks.

- Previously when a user uploads a track with a new album the new album information is not returned so if the user went and clicked create again for another track on the same album it would create a completely new album with the same name.
- When uploading a track with a new album if an image is uploaded for the track it will also be used as the album cover.
- Minor style fixes and changed https to http for api call when in local development.